### PR TITLE
@sven-herrmann pointed out that m_normalW is not initialised.

### DIFF
--- a/iir/Layout.h
+++ b/iir/Layout.h
@@ -169,7 +169,7 @@ namespace Iir {
 		int m_numPoles;
 		int m_maxPoles;
 		PoleZeroPair* m_pair;
-		double m_normalW;
+		double m_normalW = 0;
 		double m_normalGain = 1;
 	};
 


### PR DESCRIPTION
It's not fatal as all design commands set it but just in case
somebody wants to use that class in isolation. Thanks for the fix.